### PR TITLE
Do not complain that "All USB buses" carries packets that belong to other buses

### DIFF
--- a/src/usb_bus.cpp
+++ b/src/usb_bus.cpp
@@ -63,7 +63,7 @@ void usbtop::UsbBus::push(const pcap_pkthdr* h, const u_char* bytes)
 	const uint8_t device_id = bytes[11];
 	const uint16_t bus_id = *((const uint16_t*) &bytes[12]);
 
-	if (bus_id != id()) {
+	if ((bus_id != id()) && id()) {
 		std::cerr << "[bad packet] on bus " << id() << ", captured a packet claimed to be on bus " << bus_id << "." << std::endl;
 		return;
 	}


### PR DESCRIPTION
libpcap 1.8.0 reports "All USB buses" device with "Bus ID 0" since
commit 003600f9
    Include usbmon0 in the list of known devices, if it's supported.