### PR TITLE
Unbreak build against Boost 1.67 and 1.69

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 find_package(PCAP REQUIRED)
 
 # Boost thread
-find_package(Boost COMPONENTS thread system)
+find_package(Boost REQUIRED COMPONENTS thread)
 
 ##
 

--- a/include/usbtop/usb_stats.h
+++ b/include/usbtop/usb_stats.h
@@ -35,6 +35,7 @@
 #include <cstddef>
 
 #include <boost/circular_buffer.hpp>
+#include <boost/noncopyable.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
 #define LIVE_SAMPLE_COUNT 128

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,5 +21,9 @@ usb_stats.cpp
 
 add_executable(usbtop ${SRC_FILES})
 target_link_libraries(usbtop ${PCAP_LIBRARIES} ${Boost_LIBRARIES})
+if(UNIX AND NOT APPLE)
+	# Boost.Thread 1.67+ headers reference pthread_condattr_*
+	target_link_libraries(usbtop pthread)
+endif()
 
 install(TARGETS usbtop DESTINATION sbin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${BOOST_INCLUDEDIR} ${PCAP_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS} ${PCAP_INCLUDE_DIRS})
 add_definitions("-std=c++0x -Wall -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64")
 
 IF(CMAKE_BUILD_TYPE MATCHES "[Dd][Ee][Bb][Uu][Gg]")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${Boost_INCLUDE_DIRS} ${PCAP_INCLUDE_DIRS})
+include_directories(${PCAP_INCLUDE_DIRS})
 add_definitions("-std=c++0x -Wall -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64")
 
 IF(CMAKE_BUILD_TYPE MATCHES "[Dd][Ee][Bb][Uu][Gg]")
@@ -20,10 +20,6 @@ usb_stats.cpp
 )
 
 add_executable(usbtop ${SRC_FILES})
-target_link_libraries(usbtop ${PCAP_LIBRARIES} ${Boost_LIBRARIES})
-if(UNIX AND NOT APPLE)
-	# Boost.Thread 1.67+ headers reference pthread_condattr_*
-	target_link_libraries(usbtop pthread)
-endif()
+target_link_libraries(usbtop ${PCAP_LIBRARIES} Boost::thread)
 
 install(TARGETS usbtop DESTINATION sbin)


### PR DESCRIPTION
Regressed by https://github.com/boostorg/thread/commit/1e84b978b2bb. Found [downstream](https://reviews.freebsd.org/D15030) ([error log](http://package23.nyi.freebsd.org/data/111i386-default-PR227427/2018-04-16_14h20m42s/logs/errors/usbtop-0.2_1.log)). Let's use imported targets for simplicity unless they break build with ancient CMake/Boost.

```c++
$ cat foo.cc
#include <boost/thread.hpp>

void foo() {}

int main()
{
  boost::thread capturing_th(foo);
  return 0;
}

$ clang++ -fuse-ld=lld foo.cc -I/usr/local/include -L/usr/local/lib/ -lboost_thread -lboost_system
/usr/bin/ld: error: undefined symbol: pthread_condattr_init
>>> referenced by foo.cc
>>>               /tmp/foo-060c75.o:(boost::pthread::cond_init(pthread_cond*&))

/usr/bin/ld: error: undefined symbol: pthread_condattr_setclock
>>> referenced by foo.cc
>>>               /tmp/foo-060c75.o:(boost::pthread::cond_init(pthread_cond*&))

/usr/bin/ld: error: undefined symbol: pthread_condattr_destroy
>>> referenced by foo.cc
>>>               /tmp/foo-060c75.o:(boost::pthread::cond_init(pthread_cond*&))
```


@yurivict, this PR obsoletes 8025ef336089 from #13 (aka [patch-CMakeLists.txt](https://github.com/freebsd/freebsd-ports/blob/1c86500c84c5/sysutils/usbtop/files/patch-CMakeLists.txt)).
